### PR TITLE
Revert "add package: sodium"

### DIFF
--- a/packages/sodium/install
+++ b/packages/sodium/install
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -x
-set -e
-
-apt-get update -qq
-apt-get install -y libsodium-dev

--- a/packages/sodium/test.R
+++ b/packages/sodium/test.R
@@ -1,7 +1,0 @@
-# Install from CRAN
-install.packages("sodium", repos = "https://cran.rstudio.com")
-
-# Run example from the manual
-library(sodium)
-key <- sha256(charToRaw("This is a secret passphrase"))
-msg <- serialize(iris, NULL)


### PR DESCRIPTION
Reverts rstudio/shinyapps-package-dependencies#34

libsodium-dev is not available on Ubuntu Precise. This will need to wait until we upgrade our image.