### PR TITLE
Revert "add package: sodium"

### DIFF
--- a/packages/sodium/install
+++ b/packages/sodium/install
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -x
-set -e
-
-apt-get update -qq
-
-# libsodium backports for < wily
-add-apt-repository -y ppa:chris-lea/libsodium
-apt-get install -y libsodium-dev

--- a/packages/sodium/test.R
+++ b/packages/sodium/test.R
@@ -1,7 +1,0 @@
-# Install from CRAN
-install.packages("sodium", repos = "https://cran.rstudio.com")
-
-# Run example from the manual
-library(sodium)
-key <- sha256(charToRaw("This is a secret passphrase"))
-msg <- serialize(iris, NULL)


### PR DESCRIPTION
Reverts rstudio/shinyapps-package-dependencies#39

Fails due to absence of

```
options(download.file.method="curl")
```

and with that, fails with:

```
foundpkgs: sodium, /tmp/Rtmp3bpzVu/downloaded_packages/sodium_0.2.tar.gz
files: /tmp/Rtmp3bpzVu/downloaded_packages/sodium_0.2.tar.gz
* installing *source* package ‘sodium’ ...
** package ‘sodium’ successfully unpacked and MD5 sums checked
Package libsodium was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsodium.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsodium' found
Using PKG_CFLAGS=
Using PKG_LIBS=-lsodium
------------------------- ANTICONF ERROR ---------------------------
Configuration failed because libsodium was not found. Try installing:
 * deb: libsodium-dev (Debian, Ubuntu, etc)
 * rpm: libsodium-devel (Fedora, EPEL)
 * csw: libsodium_dev (Solaris)
 * brew: libsodium (OSX)
If libsodium is already installed, check that 'pkg-config' is in your
PATH and PKG_CONFIG_PATH contains a libsodium.pc file. If pkg-config
is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
--------------------------------------------------------------------
ERROR: configuration failed for package ‘sodium’
* removing ‘/usr/local/lib/R/site-library/sodium’
```