### PR TITLE
Add rPython installer

### DIFF
--- a/packages/rPython/install
+++ b/packages/rPython/install
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -x
+set -e
+
+apt-get update -qq
+apt-get install -y python2.7-dev

--- a/packages/rPython/test.R
+++ b/packages/rPython/test.R
@@ -1,0 +1,2 @@
+options(download.file.method="curl")
+install.packages("rPython", repos="https://cran.rstudio.com")


### PR DESCRIPTION
Ubuntu 14.04 image doesn't have libpython2.7-dev and python-config installed, unlike Ubuntu 12.04