### PR TITLE
Add Dockerfile for self-contained testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ sudo: required
 services:
   - docker
 
+before_install:
+  - docker build -t rstudio/r .
+
 script:
   - make all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,9 @@ touch packages/<r_package_name>/test.R
 
 5. Write this R script to install the R package and run some basic code to ensure that the package is installed correctly and functional.
 
-4. Test your install via running this command.
+4. Test your install by running these commands:
 
 ```bash
-docker run --name shinyapps-package-dependencies -v $(pwd):/shinyapps --rm cbarraford/r3x:latest /shinyapps/test <r_package_name>
+docker build -t rstudio/r .
+docker run --name shinyapps-package-dependencies -v $(pwd):/shinyapps --rm rstudio/r /shinyapps/test [r_package_name]
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:trusty
+MAINTAINER RStudio Docker <docker@rstudio.com>
+
+# add R apt repository
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+RUN echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list.d/cran-rstudio.list
+
+# add OpenJDK PPA
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86F44E2A
+RUN echo "deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main" >> /etc/apt/sources.list.d/openjdk-ppa.list
+
+# Set default locale
+RUN update-locale --reset LANG=C.UTF-8
+
+# update apt & install packages
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    biber \
+    build-essential \
+    curl \
+    jags \
+    libatlas3-base \
+    libboost-all-dev \
+    libcairo2 \
+    libcairo2-dev \
+    libfftw3-dev \
+    libgdal1-dev \
+    libgraphviz-dev \
+    libmyodbc \
+    libmysqlclient-dev \
+    libnetcdf-dev \
+    libprocps3-dev \
+    libproj-dev \
+    libprotoc-dev \
+    libxml2-dev \
+    libxt-dev \
+    libxt6 \
+    lsb-release \
+    odbc-postgresql \
+    protobuf-compiler \
+    sudo \
+    tdsodbc \
+    texinfo \
+    texlive \
+    texlive-bibtex-extra \
+    texlive-fonts-extra \
+    texlive-latex-extra \
+    texlive-xetex \
+    unixodbc \
+    unixodbc-dev \
+    wget
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openjdk-8-jdk
+
+ENV R_VERSION 3.3.1
+
+# Install R
+RUN apt-get install -y r-base-core=3.3.1-1trusty0 r-base-dev=3.3.1-1trusty0
+
+# set UTF-8
+RUN echo "LANG=C.UTF-8" >> /usr/lib/R/etc/Renviron.site

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PACKAGE_DIRS := $(wildcard packages/*)
 PACKAGES := $(notdir ${PACKAGE_DIRS})
 PACKAGE_TESTS := $(PACKAGES:%=test-%)
-DOCKER_IMAGE ?= "cbarraford/r3x:latest"
+DOCKER_IMAGE ?= "rstudio/r"
 
 test-%:
 	docker run --name shinyapps-package-dependencies -v $(CURDIR):/shinyapps --rm $(DOCKER_IMAGE) /shinyapps/test $*


### PR DESCRIPTION
This should fix the travis-ci build without us needing to release official RStudio Docker images for R, yet.