### PR TITLE
Fix unixodbc configuration for MySQL

### DIFF
--- a/packages/RODBC/install
+++ b/packages/RODBC/install
@@ -2,36 +2,9 @@
 set -x
 set -e
 
-apt-get update -qq
-
-# install freetds drivers
-apt-get install -y tdsodbc freetds-bin freetds-common freetds-dev
-
-# install postgres drivers
-apt-get install -y odbc-postgresql
-
-# write odbc config
-cat <<EOF > /etc/odbcinst.ini
-[FreeTDS]
-Description = TDS driver (Sybase/MS SQL)
-Driver      = libtdsodbc.so
-Setup       = libtdsS.so
-CPTimeout   =
-CPReuse     =
-
-[PostgreSQL ANSI]
-Description = PostgreSQL ODBC driver (ANSI version)
-Driver      = psqlodbca.so
-Setup       = libodbcpsqlS.so
-Debug       = 0
-CommLog     = 1
-UsageCount  = 1
-
-[PostgreSQL Unicode]
-Description = PostgreSQL ODBC driver (Unicode version)
-Driver      = psqlodbcw.so
-Setup       = libodbcpsqlS.so
-Debug       = 0
-CommLog     = 1
-UsageCount  = 1
+debconf-set-selections <<EOF
+libmyodbc libmyodbc/addtoodbc boolean true
+tdsodbc freetds/addtoodbc boolean true
 EOF
+
+dpkg-reconfigure -f noninteractive libmyodbc tdsodbc

--- a/test
+++ b/test
@@ -17,7 +17,7 @@ color_text () {
 DIR=`dirname $0`
 
 if [ $# -eq 0 ]; then
-    PACKAGES=$(ls -1 -d $DIR/packages/* | tr '\n' '\0' | xargs -0 -n 1 basename)
+    PACKAGES=$(ls -1 -d $DIR/packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename)
 else
     PACKAGES=$@
 fi


### PR DESCRIPTION
libmyodbc and tdsodbc do not add themselves to the odbcinst.ini file by default.

Adjust their selections and reconfigure the packages.

The odbc-postgresql package _does_ add itself.

We should migrate this change into the base images and once those roll out remove it from here.

Fixes [#127300831] and https://groups.google.com/d/msg/shinyapps-users/t3_7oZK65ik/xIYJiseDEgAJ