### PR TITLE
The Rsymphony install was failing unnoticed

### DIFF
--- a/packages/Rsymphony/install
+++ b/packages/Rsymphony/install
@@ -3,4 +3,4 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install -y coinor-libsymphony-dev # coinor-libcgl-dev
+apt-get install -y coinor-libsymphony-dev coinor-libcgl-dev

--- a/packages/Rsymphony/install
+++ b/packages/Rsymphony/install
@@ -3,4 +3,4 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install -y coinor-libsymphony-dev
+apt-get install -y coinor-libsymphony-dev coinor-libcgl-dev

--- a/packages/Rsymphony/install
+++ b/packages/Rsymphony/install
@@ -3,4 +3,4 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install -y coinor-libsymphony-dev coinor-libcgl-dev
+apt-get install -y coinor-libsymphony-dev # coinor-libcgl-dev

--- a/packages/Rsymphony/test.R
+++ b/packages/Rsymphony/test.R
@@ -1,2 +1,8 @@
-options(download.file.method="curl")
-install.packages("Rsymphony", repos="https://cran.rstudio.com")
+library('Rsymphony')
+
+obj <- c(2, 4, 3)
+mat <- matrix(c(3, 2, 1, 4, 1, 3, 2, 1, 2), nrow = 3)
+dir <- c("<=", "<=", "<=")
+rhs <- c(60, 40, 80)
+max <- TRUE
+Rsymphony_solve_LP(obj, mat, dir, rhs, max = max)

--- a/packages/Rsymphony/test.R
+++ b/packages/Rsymphony/test.R
@@ -1,3 +1,5 @@
+options(download.file.method="curl")
+install.packages("Rsymphony", repos="https://cran.rstudio.com")
 library('Rsymphony')
 
 obj <- c(2, 4, 3)

--- a/test
+++ b/test
@@ -17,41 +17,35 @@ color_text () {
 DIR=`dirname $0`
 
 if [ $# -eq 0 ]; then
-    PACKAGES=$(ls -1 -d ${DIR}/packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename)
+    PACKAGES=$(ls -1 -d $DIR/packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename)
 else
     PACKAGES=$@
 fi
 
-for PACKAGE in ${PACKAGES}; do
+for PACKAGE in $PACKAGES; do
 
-    PACKAGE_DIR=${DIR}/packages/${PACKAGE}
+    PACKAGE_DIR=$DIR/packages/$PACKAGE
 
-    if [ -f ${PACKAGE_DIR}/install ]; then
+    if [ -f $PACKAGE_DIR/install ]; then
         echo " ***** PACKAGE $PACKAGE" | purple
 
-        echo " ***** INSTALLING SYSTEM DEPENDENCIES..." | purple
-        bash ${PACKAGE_DIR}/install
+        echo " ***** INSTALLING..." | purple
+        bash $PACKAGE_DIR/install
 
-        echo " ***** INSTALLING PACKAGE..." | purple
-        R -e "install.packages('$PACKAGE', repos='http://cran.rstudio.com/'); library('$PACKAGE')"
+        echo " ***** TESTING..." | purple
+        if [ -f $PACKAGE_DIR/test.R ]; then
+            sudo R --verbose -f $PACKAGE_DIR/test.R
+        else
+            sudo R -e "install.packages('$PACKAGE', repos='http://cran.rstudio.com/'); library('$PACKAGE')"
+        fi
+
         return_code=$?
-        if [[ ${return_code} != 0 ]]; then
-            echo "Failed to install $PACKAGE" | red
-            exit ${return_code}
+        if [[ $return_code != 0 ]] ; then
+            echo "$PACKAGE... FAILED" | red
+            exit $return_code
+        else
+            echo "$PACKAGE... SUCCESS" | green
         fi
-
-        if [ -f ${PACKAGE_DIR}/test.R ]; then
-            echo " ***** TESTING..." | purple
-            R --verbose -f ${PACKAGE_DIR}/test.R
-
-            return_code=$?
-            if [[ ${return_code} != 0 ]] ; then
-                echo "$PACKAGE... FAILED" | red
-                exit ${return_code}
-            fi
-        fi
-
-        echo "$PACKAGE... SUCCESS" | green
     else
         echo "Unable to find '$PACKAGE' in $DIR/packages, exiting..." | red
         exit 1

--- a/test
+++ b/test
@@ -17,35 +17,41 @@ color_text () {
 DIR=`dirname $0`
 
 if [ $# -eq 0 ]; then
-    PACKAGES=$(ls -1 -d $DIR/packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename)
+    PACKAGES=$(ls -1 -d ${DIR}/packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename)
 else
     PACKAGES=$@
 fi
 
-for PACKAGE in $PACKAGES; do
+for PACKAGE in ${PACKAGES}; do
 
-    PACKAGE_DIR=$DIR/packages/$PACKAGE
+    PACKAGE_DIR=${DIR}/packages/${PACKAGE}
 
-    if [ -f $PACKAGE_DIR/install ]; then
+    if [ -f ${PACKAGE_DIR}/install ]; then
         echo " ***** PACKAGE $PACKAGE" | purple
 
-        echo " ***** INSTALLING..." | purple
-        bash $PACKAGE_DIR/install
+        echo " ***** INSTALLING SYSTEM DEPENDENCIES..." | purple
+        bash ${PACKAGE_DIR}/install
 
-        echo " ***** TESTING..." | purple
-        if [ -f $PACKAGE_DIR/test.R ]; then
-            sudo R --verbose -f $PACKAGE_DIR/test.R
-        else
-            sudo R -e "install.packages('$PACKAGE', repos='http://cran.rstudio.com/'); library('$PACKAGE')"
-        fi
-
+        echo " ***** INSTALLING PACKAGE..." | purple
+        R -e "install.packages('$PACKAGE', repos='http://cran.rstudio.com/'); library('$PACKAGE')"
         return_code=$?
-        if [[ $return_code != 0 ]] ; then
-            echo "$PACKAGE... FAILED" | red
-            exit $return_code
-        else
-            echo "$PACKAGE... SUCCESS" | green
+        if [[ ${return_code} != 0 ]]; then
+            echo "Failed to install $PACKAGE" | red
+            exit ${return_code}
         fi
+
+        if [ -f ${PACKAGE_DIR}/test.R ]; then
+            echo " ***** TESTING..." | purple
+            R --verbose -f ${PACKAGE_DIR}/test.R
+
+            return_code=$?
+            if [[ ${return_code} != 0 ]] ; then
+                echo "$PACKAGE... FAILED" | red
+                exit ${return_code}
+            fi
+        fi
+
+        echo "$PACKAGE... SUCCESS" | green
     else
         echo "Unable to find '$PACKAGE' in $DIR/packages, exiting..." | red
         exit 1


### PR DESCRIPTION
It has an additional requirement on the CGL library.

Adjust how we run the tests to always perform the package install and test it's result, instead of relying upon `test.R` to perform the install.