### PR TITLE
add support for liblwgeom (needed by st_make_valid)

### DIFF
--- a/packages/sf/install
+++ b/packages/sf/install
@@ -6,4 +6,4 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 314DF160
 echo "deb http://ppa.launchpad.net/ubuntugis/ppa/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/ubuntugis-ppa.list
 
 apt-get update -qq
-apt-get install -y libudunits2-dev libgdal-dev libgeos-dev libproj-dev
+apt-get install -y libudunits2-dev libgdal-dev libgeos-dev libproj-dev liblwgeom-dev

--- a/packages/sf/test.R
+++ b/packages/sf/test.R
@@ -6,3 +6,8 @@ library(sf)
 x = st_point(0:1)
 y = st_point(3:4)
 st_intersects(x, y)
+
+# st_make_valid:
+x = st_sfc(st_polygon(list(rbind(c(0,0),c(0.5,0),c(0.5,0.5),c(0.5,0),c(1,0),c(1,1),c(0,1),c(0,0)))))
+y = st_make_valid(x)
+st_is_valid(y) # TRUE


### PR DESCRIPTION
This PR adds liblwgeom, which is automatically linked to by sf >= 0.4-0. It is not available on CRAN binary builds, but many (linux and OSX) users install this package themselves, and build sf from source. It's only a small additional dependency, after those we already have for sf.