### PR TITLE
Support for tensorflow 1.1.0

### DIFF
--- a/packages/tensorflow/install
+++ b/packages/tensorflow/install
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+set -e
+
+apt-get update -qq
+apt-get install -y python-pip python-dev
+
+pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.1.0-cp27-none-linux_x86_64.whl
+pip install scipy h5py pyyaml requests Pillow

--- a/packages/tensorflow/test.R
+++ b/packages/tensorflow/test.R
@@ -1,0 +1,4 @@
+options(download.file.method="curl")
+install.packages("tensorflow", repos="https://cran.rstudio.com")
+library('tensorflow')
+sess <- tf$Session()


### PR DESCRIPTION
Pypi has a release candidate for 1.2.0, but not 1.1.0