### PR TITLE
Add package mapview support

### DIFF
--- a/packages/mapview/install
+++ b/packages/mapview/install
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -x
+set -e
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 314DF160
+echo "deb http://ppa.launchpad.net/ubuntugis/ppa/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/ubuntugis-ppa.list
+
+apt-get update -qq
+apt-get install -y libudunits2-dev libgdal-dev libgeos-dev libproj-dev liblwgeom-dev

--- a/packages/mapview/test.R
+++ b/packages/mapview/test.R
@@ -1,0 +1,6 @@
+# Install from CRAN
+install.packages("mapview", repos = "https://cran.rstudio.com")
+
+# Run example
+library(mapview)
+mapview(breweries)

--- a/packages/mapview/test.R
+++ b/packages/mapview/test.R
@@ -1,6 +1,9 @@
 # Install from CRAN
 install.packages("mapview", repos = "https://cran.rstudio.com")
 
-# Run example
+# Run examples
+
 library(mapview)
-mapview(breweries)
+
+mapview(breweries) # Easiest test, on lat-long data
+mapview(poppendorf[[5]]) # This test requires re-projection


### PR DESCRIPTION
At the moment it is impossible to use the `mapview` package on Shinyapps (see [this issue](https://github.com/r-spatial/mapview/issues/61)).

This pull request hopefully resolves this problem.