### PR TITLE
install keras as part of tensorflow dependencies

### DIFF
--- a/packages/tensorflow/install
+++ b/packages/tensorflow/install
@@ -9,4 +9,4 @@ python get-pip.py
 rm get-pip.py
 
 pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.2.1-cp27-none-linux_x86_64.whl
-pip install scipy h5py pyyaml requests Pillow
+pip install keras scipy h5py pyyaml requests Pillow


### PR DESCRIPTION
The default backend implementation for the keras package now requires the keras python package (i.e. apps using keras master will break until this is merged and deployed).