### PR TITLE
[Sodium] Dont break xenial

### DIFF
--- a/packages/sodium/install
+++ b/packages/sodium/install
@@ -2,8 +2,27 @@
 set -x
 set -e
 
+OS_PLATFORM=$(lsb_release -cs)
+
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7917B12
-echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/libsodium-ppa.list
+
+function add_repo {
+    echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu $OS_PLATFORM main" >> /etc/apt/sources.list.d/libsodium-ppa.list
+}
+
+# check for supported platform (whitelisted ubuntu versions)
+if [ $OS_PLATFORM == "precise" ]; then
+    add_repo
+elif [ $OS_PLATFORM == "trusty" ]; then
+    add_repo
+elif [ $OS_PLATFORM == "vivid" ]; then
+    add_repo
+else
+    echo "This platform is unsupported ($OS_PLATFORM) by the apt repository. Skipping"
+    test -f /etc/apt/sources.list.d/libsodium-ppa.list && rm /etc/apt/sources.list.d/libsodium-ppa.list
+    exit 0
+fi
+
 
 apt-get update -qq
 apt-get install -y libsodium-dev

--- a/packages/sodium/install
+++ b/packages/sodium/install
@@ -4,23 +4,19 @@ set -e
 
 OS_DISTRIBUTION=$(lsb_release -cs)
 
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7917B12
-
 function add_repo {
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7917B12
     echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu $OS_DISTRIBUTION main" >> /etc/apt/sources.list.d/libsodium-ppa.list
 }
 
 # check for supported platform (whitelisted ubuntu versions)
+# xenial does NOT need to add the ppa
 if [ $OS_DISTRIBUTION == "precise" ]; then
     add_repo
 elif [ $OS_DISTRIBUTION == "trusty" ]; then
     add_repo
 elif [ $OS_DISTRIBUTION == "vivid" ]; then
     add_repo
-else
-    echo "This platform is unsupported ($OS_DISTRIBUTION) by the apt repository. Skipping"
-    test -f /etc/apt/sources.list.d/libsodium-ppa.list && rm /etc/apt/sources.list.d/libsodium-ppa.list
-    exit 0
 fi
 
 

--- a/packages/sodium/install
+++ b/packages/sodium/install
@@ -2,23 +2,23 @@
 set -x
 set -e
 
-OS_PLATFORM=$(lsb_release -cs)
+OS_DISTRIBUTION=$(lsb_release -cs)
 
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7917B12
 
 function add_repo {
-    echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu $OS_PLATFORM main" >> /etc/apt/sources.list.d/libsodium-ppa.list
+    echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu $OS_DISTRIBUTION main" >> /etc/apt/sources.list.d/libsodium-ppa.list
 }
 
 # check for supported platform (whitelisted ubuntu versions)
-if [ $OS_PLATFORM == "precise" ]; then
+if [ $OS_DISTRIBUTION == "precise" ]; then
     add_repo
-elif [ $OS_PLATFORM == "trusty" ]; then
+elif [ $OS_DISTRIBUTION == "trusty" ]; then
     add_repo
-elif [ $OS_PLATFORM == "vivid" ]; then
+elif [ $OS_DISTRIBUTION == "vivid" ]; then
     add_repo
 else
-    echo "This platform is unsupported ($OS_PLATFORM) by the apt repository. Skipping"
+    echo "This platform is unsupported ($OS_DISTRIBUTION) by the apt repository. Skipping"
     test -f /etc/apt/sources.list.d/libsodium-ppa.list && rm /etc/apt/sources.list.d/libsodium-ppa.list
     exit 0
 fi


### PR DESCRIPTION
The sodium install script currently breaks apt-get on xenial because it adds a repository that doesn't exist which causes `apt-get update` to exit non-zero.

If you go to the [repo](http://ppa.launchpad.net/chris-lea/libsodium/ubuntu/dists), you will see the only distributions supported is `vivid`, `precise`, and `trusty`.

The change creates a "whitelist" of supported distributions and only adds the repo if its a supported distro for that machine.