### PR TITLE
update imagemagick from PPA

### DIFF
--- a/packages/magick/install
+++ b/packages/magick/install
@@ -2,5 +2,8 @@
 set -x
 set -e
 
+# PPA has recent ImageMagick versions for for Ubuntu Trusty/Xenial
+apt-get install -y python-software-properties
+add-apt-repository -y ppa:opencpu/imagemagick
 apt-get update -qq
 apt-get install -y libmagick++-dev


### PR DESCRIPTION
The version of imagemagick on Ubuntu Trusty and Xenial is pretty outdated and has tons of issues, some security problems as well.

This PPA has build of the latest stable version from Debian/Ubuntu, backported to Trusty and Xenial. I highly recommend to use this version on the server.