### PR TITLE
force use of tensorflow v1.4.1

### DIFF
--- a/packages/tensorflow/install
+++ b/packages/tensorflow/install
@@ -8,5 +8,6 @@ curl -O https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 rm get-pip.py
 
-pip install --upgrade tensorflow keras scipy h5py pyyaml requests Pillow
+pip install --upgrade tensorflow==1.4.1
+pip install --upgrade keras scipy h5py pyyaml requests Pillow
 


### PR DESCRIPTION
tensorflow v1.5 is being built on ubuntu 16.04 containers so may have glibc version issues with ubuntu 14.04. from their release notes:

> Our Linux binaries are built using ubuntu 16 containers, potentially introducing glibc incompatibility issues with ubuntu 14.