### PR TITLE
update test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,5 @@ touch packages/<r_package_name>/test.R
 4. Test your install by running these commands:
 
 ```bash
-make test-trusty-[r_package_name]
-make test-xenial-[r_package_name]
+make test-[r_package_name]
 ```


### PR DESCRIPTION
The past version `make test-trusty-[r_package_name]` does not appear to work anymore; fails with (here, `r_package_name = pensieve`): 

```
Maximilians-MacBook-Pro:shinyapps-package-dependencies max$ make test-xenial-pensieve
docker run --name shinyapps-package-dependencies -v /Users/max/GitHub/shinyapps-package-dependencies:/shinyapps --rm "rstudio/r" /shinyapps/test xenial-pensieve
Unable to find 'xenial-pensieve' in /shinyapps/packages, exiting...
```
 
`make test-[r_package_name]` works just fine.

Maybe the docs just weren't updated here?