### PR TITLE
Install the latest version of tensorflow

### DIFF
--- a/packages/tensorflow/install
+++ b/packages/tensorflow/install
@@ -8,6 +8,5 @@ curl -O https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 rm get-pip.py
 
-pip install --upgrade tensorflow==1.4.1
-pip install --upgrade keras scipy h5py pyyaml requests Pillow
+pip install --upgrade tensorflow keras scipy h5py pyyaml requests Pillow
 


### PR DESCRIPTION
Previously was hard-coded to 1.4.1 to avoid issues with tensorflow binaries built on 16.04. This decision appears to have been reverted so more recent binaries should work.