### PR TITLE
Fix the gdalUtils install

### DIFF
--- a/packages/gdalUtils/install
+++ b/packages/gdalUtils/install
@@ -6,4 +6,4 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 314DF160
 echo "deb http://ppa.launchpad.net/ubuntugis/ppa/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/ubuntugis-ppa.list
 
 apt-get update -qq
-apt-get install -y gdal-bin
+apt-get install -y libgdal-dev libproj-dev gdal-bin


### PR DESCRIPTION
It depends upon `rgdal`, which requires a higher minimum version
of GDAL than what is in the base docker image. Our `rgdal` installer
does the right thing, but we don't trigger additional install scripts
during testing.