### PR TITLE
added x264 to animation install

### DIFF
--- a/packages/animation/install
+++ b/packages/animation/install
@@ -5,16 +5,14 @@ set -e
 OS_DISTRIBUTION=$(lsb_release -cs)
 
 # need for add-apt-repository
-sudo apt-get install -y software-properties-common
+apt-get install -y software-properties-common
 
 # check for supported platform (whitelisted ubuntu versions)
 if [ $OS_DISTRIBUTION == "trusty" ]; then
-	sudo add-apt-repository ppa:mc3man/trusty-media
+	add-apt-repository ppa:mc3man/trusty-media
 # else 
-# 	sudo add-apt-repository ppa:jonathonf/ffmpeg-3
+# 	add-apt-repository ppa:jonathonf/ffmpeg-3
 fi
 
-sudo apt-get update -qq
-sudo apt-get -y dist-upgrade
-sudo apt-get update -qq
-sudo apt-get install -y ffmpeg graphicsmagick libav-tools pdftk x264 x265
+apt-get update -qq
+apt-get install -y ffmpeg graphicsmagick libav-tools pdftk x264 x265

--- a/packages/animation/install
+++ b/packages/animation/install
@@ -3,4 +3,4 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install -y graphicsmagick libav-tools pdftk
+apt-get install -y graphicsmagick libav-tools pdftk x264 x265

--- a/packages/animation/install
+++ b/packages/animation/install
@@ -2,5 +2,19 @@
 set -x
 set -e
 
-apt-get update -qq
-apt-get install -y graphicsmagick libav-tools pdftk x264 x265
+OS_DISTRIBUTION=$(lsb_release -cs)
+
+# need for add-apt-repository
+sudo apt-get install -y software-properties-common
+
+# check for supported platform (whitelisted ubuntu versions)
+if [ $OS_DISTRIBUTION == "trusty" ]; then
+	sudo add-apt-repository ppa:mc3man/trusty-media
+# else 
+# 	sudo add-apt-repository ppa:jonathonf/ffmpeg-3
+fi
+
+sudo apt-get update -qq
+sudo apt-get -y dist-upgrade
+sudo apt-get update -qq
+sudo apt-get install -y ffmpeg graphicsmagick libav-tools pdftk x264 x265

--- a/packages/animation/test.R
+++ b/packages/animation/test.R
@@ -20,6 +20,14 @@ animation::saveVideo({
   animation::brownian.motion(pch = 21, cex = 5, col = "red", bg = "yellow")
 }, video.name = "BM.mp4", other.opts = "-pix_fmt yuv420p -b 300k -c:v libx264")
 
+animation::saveVideo({
+  par(mar = c(3, 3, 1, 0.5), mgp = c(2, 0.5, 0), tcl = -0.3, cex.axis = 0.8,
+      cex.lab = 0.8, cex.main = 1)
+  animation::ani.options(interval = 0.05, nmax = 300)
+  animation::brownian.motion(pch = 21, cex = 5, col = "red", bg = "yellow")
+}, video.name = "BM.mp4", other.opts = "-pix_fmt yuv420p -b 300k -c:v libx265")
+
+
 pathPDFTK = system2('which',args = 'pdftk',stdout = TRUE)
 animation::ani.options(pdftk = pathPDFTK)
 

--- a/packages/animation/test.R
+++ b/packages/animation/test.R
@@ -13,6 +13,13 @@ animation::saveVideo({
 	animation::brownian.motion(pch = 21, cex = 5, col = "red", bg = "yellow")
 }, video.name = "BM.mp4", other.opts = "-pix_fmt yuv420p -b 300k")
 
+animation::saveVideo({
+  par(mar = c(3, 3, 1, 0.5), mgp = c(2, 0.5, 0), tcl = -0.3, cex.axis = 0.8,
+      cex.lab = 0.8, cex.main = 1)
+  animation::ani.options(interval = 0.05, nmax = 300)
+  animation::brownian.motion(pch = 21, cex = 5, col = "red", bg = "yellow")
+}, video.name = "BM.mp4", other.opts = "-pix_fmt yuv420p -b 300k -c:v libx264")
+
 pathPDFTK = system2('which',args = 'pdftk',stdout = TRUE)
 animation::ani.options(pdftk = pathPDFTK)
 


### PR DESCRIPTION
I've added x264 to the animation install as it is a common encoder for mp4 formats in Linux.  I have added an additional test to the `test.R` so that it will execute with that codec.  The x265 codec is also commonly used, so that was added as well.  @yihui 