### PR TITLE
including texlive-lang-portuguese

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant/
+.Rproj.user

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update -qq && \
     texlive-fonts-extra \
     texlive-latex-extra \
     texlive-xetex \
+    texlive-lang-portuguese \
     unixodbc \
     unixodbc-dev \
     wget

--- a/shinyapps-package-dependencies.Rproj
+++ b/shinyapps-package-dependencies.Rproj
@@ -1,0 +1,15 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Makefile


### PR DESCRIPTION
Including texlive-lang-portuguese lib dependence to make portuguese language available in Rmd/latex documents.