### PR TITLE
add packages websocket & pagedown support

### DIFF
--- a/packages/pagedown/install
+++ b/packages/pagedown/install
@@ -3,13 +3,13 @@
 set -x
 set -e
 
-# tests have failed without Pandoc
+# the functional test has failed without Pandoc
 # pagedown requires Pandoc >= 2.2.3
 wget https://github.com/jgm/pandoc/releases/download/2.2.3.1/pandoc-2.2.3.1-1-amd64.deb
 dpkg -i pandoc-2.2.3.1-1-amd64.deb
 rm pandoc-2.2.3.1-1-amd64.deb
 
-# install libssl-dev for the websocket package
+# install libssl-dev for the websocket package. This is required for the bionic image (this wasn't necessary for xenial)
 # install chromium to use pagedown::chrome_print()
 apt-get update -qq
 apt-get install -y \

--- a/packages/pagedown/install
+++ b/packages/pagedown/install
@@ -3,12 +3,6 @@
 set -x
 set -e
 
-# the functional test has failed without Pandoc
-# pagedown requires Pandoc >= 2.2.3
-wget https://github.com/jgm/pandoc/releases/download/2.2.3.1/pandoc-2.2.3.1-1-amd64.deb
-dpkg -i pandoc-2.2.3.1-1-amd64.deb
-rm pandoc-2.2.3.1-1-amd64.deb
-
 apt-get update -qq
 
 # install chromium to use pagedown::chrome_print()

--- a/packages/pagedown/install
+++ b/packages/pagedown/install
@@ -11,10 +11,5 @@ rm pandoc-2.2.3.1-1-amd64.deb
 
 apt-get update -qq
 
-# install libssl-dev for the websocket package. No need for xenial.
-if [ $(lsb_release -cs) == "bionic" ] ; then
-  apt-get install -y libssl-dev
-fi
-
 # install chromium to use pagedown::chrome_print()
 apt-get install -y chromium-browser

--- a/packages/pagedown/install
+++ b/packages/pagedown/install
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# tests have failed without Pandoc
+# pagedown requires Pandoc >= 2.2.3
+wget https://github.com/jgm/pandoc/releases/download/2.2.3.1/pandoc-2.2.3.1-1-amd64.deb
+dpkg -i pandoc-2.2.3.1-1-amd64.deb
+rm pandoc-2.2.3.1-1-amd64.deb
+
+# install libssl-dev for the websocket package
+# install chromium to use pagedown::chrome_print()
+apt-get update -qq
+apt-get install -y \
+        libssl-dev \
+        chromium-browser

--- a/packages/pagedown/install
+++ b/packages/pagedown/install
@@ -9,9 +9,12 @@ wget https://github.com/jgm/pandoc/releases/download/2.2.3.1/pandoc-2.2.3.1-1-am
 dpkg -i pandoc-2.2.3.1-1-amd64.deb
 rm pandoc-2.2.3.1-1-amd64.deb
 
-# install libssl-dev for the websocket package. This is required for the bionic image (this wasn't necessary for xenial)
-# install chromium to use pagedown::chrome_print()
 apt-get update -qq
-apt-get install -y \
-        libssl-dev \
-        chromium-browser
+
+# install libssl-dev for the websocket package. No need for xenial.
+if [ $(lsb_release -cs) == "bionic" ] ; then
+  apt-get install -y libssl-dev
+fi
+
+# install chromium to use pagedown::chrome_print()
+apt-get install -y chromium-browser

--- a/packages/pagedown/test.R
+++ b/packages/pagedown/test.R
@@ -1,0 +1,19 @@
+options(download.file.method = "curl")
+install.packages("pagedown", repos = "https://cran.rstudio.com", type = "source")
+
+# Test against Chromium installation
+pagedown::find_chrome()
+
+# Functional test
+source_file <- system.file(
+  "rmarkdown/templates/html-paged/skeleton/skeleton.Rmd",
+  package = "pagedown",
+  mustWork = TRUE
+)
+
+pagedown::chrome_print(
+  source_file, 
+  tempfile(), 
+  extra_args = c("--disable-gpu", "--no-sandbox"), 
+  verbose = 1
+)

--- a/packages/pagedown/test.R
+++ b/packages/pagedown/test.R
@@ -4,7 +4,7 @@ install.packages("pagedown", repos = "https://cran.rstudio.com", type = "source"
 # Test against Chromium installation
 pagedown::find_chrome()
 
-# Functional test
+# Functional test (Pandoc is required)
 source_file <- system.file(
   "rmarkdown/templates/html-paged/skeleton/skeleton.Rmd",
   package = "pagedown",

--- a/packages/pagedown/test.R
+++ b/packages/pagedown/test.R
@@ -3,17 +3,3 @@ install.packages("pagedown", repos = "https://cran.rstudio.com", type = "source"
 
 # Test against Chromium installation
 pagedown::find_chrome()
-
-# Functional test (Pandoc is required)
-source_file <- system.file(
-  "rmarkdown/templates/html-paged/skeleton/skeleton.Rmd",
-  package = "pagedown",
-  mustWork = TRUE
-)
-
-pagedown::chrome_print(
-  source_file, 
-  tempfile(), 
-  extra_args = c("--disable-gpu", "--no-sandbox"), 
-  verbose = 1
-)

--- a/packages/websocket/install
+++ b/packages/websocket/install
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# install libssl-dev for bionic image. No need for xenial.
+if [ $(lsb_release -cs) == "bionic" ] ; then
+  apt-get update -qq
+  apt-get install -y libssl-dev
+fi

--- a/packages/websocket/test.R
+++ b/packages/websocket/test.R
@@ -1,0 +1,25 @@
+options(download.file.method = "curl")
+install.packages("websocket", repos = "https://cran.rstudio.com", type = "source")
+
+library(websocket)
+
+timeout <- 30
+websocket_test_passed <- FALSE
+
+ws <- WebSocket$new("wss://echo.websocket.org", autoConnect = FALSE)
+websocket_msg <- paste(sample(letters, 8), collapse = "")
+ws$onMessage(function(event) {
+  on.exit(ws$close())
+  stopifnot(identical(event$data, websocket_msg))
+  websocket_test_passed <<- TRUE
+})
+ws$onOpen(function(event) {
+  ws$send(websocket_msg)
+})
+t0 <- Sys.time()
+ws$connect()
+
+while (as.numeric(difftime(Sys.time(), t0, units = "secs")) < timeout && ws$readyState() < 3) {
+  later::run_now()
+}
+stopifnot(websocket_test_passed)


### PR DESCRIPTION
Hi,

Following [this question](https://community.rstudio.com/t/error-after-using-pagedown-to-generate-a-pdf-from-html-in-a-shinyapp/45999?u=rlesur) on RStudio Community, here is a PR to add the support for the [pagedown](https://cran.r-project.org/package=pagedown) package on shinyapps.io.

I've locally tested against xenial and bionic.

I want to warn you that I had to add a Pandoc installation step to pass a basic functional test. I was surprised because I thought that Pandoc was already installed on shinyapps.io. Tell me if I must remove this step.

Another point: pagedown depends on the websocket package.  
For the bionic image, the websocket package installation failed because `libssl-dev` was not installed.
For the xenial image, the websocket package was correctly installed.