### PR TITLE
Fix tests for redland and tensorflow packages

### DIFF
--- a/packages/redland/test.R
+++ b/packages/redland/test.R
@@ -10,7 +10,6 @@ parseFileIntoModel(parser, world, system.file("extdata", "dc.rdf", package="redl
 queryString <- 'PREFIX dc: <http://purl.org/dc/elements/1.1/> SELECT ?a ?c WHERE { ?a dc:creator ?c . }'
 query <- new("Query", world, queryString, base_uri=NULL, query_language="sparql", query_uri=NULL)
 queryResult <- executeQuery(query, model)
-result <- getNextResult(queryResult)
-cat(z <- sprintf("Result from query: %s\n", result))
-stopifnot(length(z)==2)
-
+results <- getResults(query, model)
+cat(sprintf("Result from query: %s\n", results))
+freeQuery(query)

--- a/packages/tensorflow/install
+++ b/packages/tensorflow/install
@@ -8,7 +8,5 @@ curl -O https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 rm get-pip.py
 
-# Use latest version of setuptools
-pip install --upgrade setuptools
-
 pip install --upgrade tensorflow keras scipy h5py pyyaml requests Pillow
+

--- a/packages/tensorflow/install
+++ b/packages/tensorflow/install
@@ -8,5 +8,7 @@ curl -O https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 rm get-pip.py
 
-pip install --upgrade tensorflow keras scipy h5py pyyaml requests Pillow
+# Use latest version of setuptools
+pip install --upgrade setuptools
 
+pip install --upgrade tensorflow keras scipy h5py pyyaml requests Pillow

--- a/packages/tensorflow/test.R
+++ b/packages/tensorflow/test.R
@@ -1,4 +1,4 @@
 options(download.file.method="curl")
 install.packages("tensorflow", repos="https://cran.rstudio.com")
 library('tensorflow')
-sess <- tf$Session()
+sess <- tf_version()


### PR DESCRIPTION
The Travis builds for the two latest PRs (#216 and #220) have failed because of [packages/redland/test.R](https://github.com/rstudio/shinyapps-package-dependencies/blob/master/packages/redland/test.R) which needs to be updated after https://github.com/ropensci/redland-bindings/issues/79.

Here is a PR to fix this test. IMO, it should be merged ASAP and before the awaiting PR.

This closes ropensci/redland-bindings#83