### PR TITLE
Allow lwgeom to pass test

### DIFF
--- a/packages/lwgeom/test.R
+++ b/packages/lwgeom/test.R
@@ -1,5 +1,9 @@
-# Install from CRAN
-install.packages("lwgeom", repos = "https://cran.rstudio.com")
+# 0.2-3 (CRAN head as of 2020-05-20) fails to install on Ubuntu 16.04 due to:
+# https://github.com/r-spatial/lwgeom/commit/08233333e7909c6c0ede0f50c94d9f5130f11c76
+# GitHub (as of 2020-05-20) fails to install because it now requires GEOS >= 3.6.0, which Ubuntu GIS does
+# not provide for Xenial.
+install.packages("devtools", repos = "https://cran.rstudio.com")
+devtools::install_version("lwgeom", version = "0.2-1", repos = "https://cran.rstudio.com")
 
 # Run example
 library(sf)


### PR DESCRIPTION
Neither the current CRAN version and current GitHub are actually installable
(for different reasons) so test against an older CRAN version for now.