### PR TITLE
add cran-libgit2 ppa for gert install

### DIFF
--- a/packages/gert/install
+++ b/packages/gert/install
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -x
+set -e
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xb3cf35c315b55a9f
+echo "deb http://ppa.launchpad.net/cran/libgit2/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/cran-libgit2-ppa.list
+
+apt-get update -qq
+apt-get install -y libgit2-dev

--- a/packages/gert/install
+++ b/packages/gert/install
@@ -2,8 +2,12 @@
 set -x
 set -e
 
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xb3cf35c315b55a9f
-echo "deb http://ppa.launchpad.net/cran/libgit2/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/cran-libgit2-ppa.list
+OS_CODENAME=$(lsb_release -cs)
 
-apt-get update -qq
-apt-get install -y libgit2-dev
+# install libgit2 on xenial only
+if [ "${OS_CODENAME}" == "xenial" ] ; then
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xb3cf35c315b55a9f
+  echo "deb http://ppa.launchpad.net/cran/libgit2/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/cran-libgit2-ppa.list
+  apt-get update -qq
+  apt-get install -y libgit2-dev
+fi

--- a/packages/gert/install
+++ b/packages/gert/install
@@ -5,7 +5,7 @@ set -e
 OS_CODENAME=$(lsb_release -cs)
 
 # install libgit2 on xenial only
-if [ "${OS_CODENAME}" == "xenial" ] ; then
+if [ "${OS_CODENAME}" == "xenial" ]; then
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xb3cf35c315b55a9f
   echo "deb http://ppa.launchpad.net/cran/libgit2/ubuntu $(lsb_release -cs) main" >> /etc/apt/sources.list.d/cran-libgit2-ppa.list
   apt-get update -qq

--- a/packages/gert/test.R
+++ b/packages/gert/test.R
@@ -1,0 +1,4 @@
+options(download.file.method="curl")
+
+# gert fails at compile-time without a functioning libgit2 version on xenial
+install.packages("gert", repos="https://cran.rstudio.com")


### PR DESCRIPTION
`usethis` recently began depending on `gert` which will not function on ubuntu xenial without a more-recent version of `libgit2`

relates to (and once deployed should resolve the underlying issue in): https://github.com/rstudio/rsconnect/issues/473