### PR TITLE
Add support for `textshaping`

### DIFF
--- a/packages/textshaping/install
+++ b/packages/textshaping/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+set -e
+
+apt-get update -qq
+apt-get install -y libharfbuzz-dev libfribidi-dev

--- a/packages/textshaping/test.R
+++ b/packages/textshaping/test.R
@@ -1,0 +1,3 @@
+options(download.file.method="curl")
+install.packages("textshaping", repos="https://cran.rstudio.com")
+textshaping::text_width("test string")


### PR DESCRIPTION
Fixes #262
Fixes #276

From the issue in #262 

```
--------------------------- [ANTICONF] -------------------------------- 
Configuration failed to find the harfbuzz freetype2 fribidi library. Try installing: 
* deb: libharfbuzz-dev libfribidi-dev (Debian, Ubuntu, etc) 
```

