### PR TITLE
Fix failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+### UPDATED
+* `RSelenium` now sets `geckover = NULL` since downloading `geckodriver` was breaking the tests
+* `ragg` add 2 required system packages to the install
+
+### REMOVED
+* `rtiff` was removed from CRAN on January 20th 2021.  Therefore we've removed it as well.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## March 10th 2021
+
 ### UPDATED
 * `RSelenium` now sets `geckover = NULL` since downloading `geckodriver` was breaking the tests
 * `ragg` add 2 required system packages to the install

--- a/packages/RSelenium/test.R
+++ b/packages/RSelenium/test.R
@@ -1,4 +1,4 @@
 options(download.file.method="curl")
 install.packages("RSelenium", repos="https://cran.rstudio.com")
-rD <- RSelenium::rsDriver(browser = "phantomjs")
+rD <- RSelenium::rsDriver(browser = "phantomjs", geckover = NULL)
 rD[["server"]]$stop()

--- a/packages/ragg/install
+++ b/packages/ragg/install
@@ -3,4 +3,4 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install -y libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev
+apt-get install -y libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libharfbuzz-dev libfribidi-dev

--- a/packages/rtiff/install
+++ b/packages/rtiff/install
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -x
-set -e
-
-apt-get update -qq
-apt-get install -y libtiff-dev


### PR DESCRIPTION
**Remove geckodriver from RSelenium test**
Sometime in the last 9 months geckodriver releases started including *.tar.gz.asc files, which is breaking the download.  See https://github.com/mozilla/geckodriver/releases/ Rather than fix that, just don't use geckodriver

**Install extra requirements for ragg**
There are a couple of new requirements for ragg it seems.

**Remove rtiff**
rtiff was removed from cran on jan 20th 2021: 
![image](https://user-images.githubusercontent.com/266698/110680945-3e51c580-81a7-11eb-9809-ee458273f78e.png)
