### PR TITLE
add libpcre2-dev to the image

### DIFF
--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -37,6 +37,7 @@ RUN apt-get update -qq && \
     libgsl0-dev \
     libmysqlclient-dev \
     libnetcdf-dev \
+    libpcre2-dev \
     libprocps4-dev \
     libproj-dev \
     libprotoc-dev \


### PR DESCRIPTION
This is to fix:

```
***** TESTING...
/opt/R/4.0.4/lib/R/bin/exec/R: error while loading shared libraries: libpcre2-8.so.0: cannot open shared object file: No such file or directory
ChemmineOB... FAILED
Makefile:14: recipe for target 'test-all-xenial' failed
make: *** [test-all-xenial] Error 127
```

