### PR TITLE
[pagedown] use Google Chrome instead of Chromium

### DIFF
--- a/packages/pagedown/install
+++ b/packages/pagedown/install
@@ -5,5 +5,7 @@ set -e
 
 apt-get update -qq
 
-# install chromium to use pagedown::chrome_print()
-apt-get install -y chromium-browser
+# install chrome to use pagedown::chrome_print()
+curl -LO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+apt-get install -y ./google-chrome-stable_current_amd64.deb
+rm google-chrome-stable_current_amd64.deb

--- a/packages/pagedown/test.R
+++ b/packages/pagedown/test.R
@@ -3,3 +3,13 @@ install.packages("pagedown", repos = "https://cran.rstudio.com", type = "source"
 
 # Test against Chromium installation
 pagedown::find_chrome()
+
+# Test PDF generation (functional test)
+pagedown::chrome_print(
+    file.path(R.home("doc"), "manual", "R-FAQ.html"),
+    tempfile(fileext = ".pdf"),
+    # use --no-sandbox flag because this code is executed in a container
+    extra_args = c("--disable-gpu", "--no-sandbox"),
+    # for diagnosis on failure
+    verbose = 2
+)


### PR DESCRIPTION
This PR proposes to install Chrome instead of Chromium to support `pagedown::chrome_print()`.

Until bionic, Chromium is available as a deb file. However since disco, Chromium is only distributed as a snap package but `snapd` does not work in containers.  
The most simple workaround is to use Chrome instead of Chromium.

FYI, https://github.com/rstudio/shinyapps-package-dependencies/pull/291/commits/8a47293beeb1e380119df7537bdc16eeda554cdd re-introduces a functional test that was removed by https://github.com/rstudio/shinyapps-package-dependencies/pull/220/commits/3bdedd10a4dcfc2d1dcc417ce25397a43de2cb0c (#290 would have been detected by such a test).  
Tell me whether you prefer that I remove it again.

Fix #290 