### PR TITLE
Expand package tesseract support include French language

### DIFF
--- a/packages/tesseract/install
+++ b/packages/tesseract/install
@@ -4,4 +4,4 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install -y libtesseract-dev libleptonica-dev tesseract-ocr-eng
+apt-get install -y libtesseract-dev libleptonica-dev tesseract-ocr-eng tesseract-ocr-fra

--- a/packages/tesseract/test.R
+++ b/packages/tesseract/test.R
@@ -3,5 +3,7 @@ install.packages("tesseract", repos="https://cran.rstudio.com")
 
 library("tesseract")
 
-text <- ocr("https://jeroen.github.io/images/testocr.png")
-nchar(text) == 287
+text_eng <- ocr("https://jeroen.github.io/images/testocr.png", engine = (language = "eng"))
+nchar(text_eng) == 286
+text_fra <- ocr("https://upload.wikimedia.org/wikipedia/commons/a/ab/IGAS_Rapport.png", engine = (language = "fra"))
+nchar(text_fra) == 3360


### PR DESCRIPTION
The tesseract package uses training data that is language specific. The current support for shinyapp includes training data for documents written in English (linux package 'tesseract-ocr-eng'), but no other languages. I need to OCR documents in French, so I add the French language support, intalling the linux package 'tesseract-ocr-fra'. Adding support for the most common languages could be useful (such as `tesseract-ocr-spa` for spanish, see [here the list of supported languages](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html)).

