### PR TITLE
Install Chrome for `chromote`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ R_VERSION := 4.0.4
 docker-build-%:
 	docker build -t rstudio/shinyapps-package-dependencies:$* --build-arg R_VERSION=$(R_VERSION) -f Dockerfile.$* .
 
-test-xenial-%:
+test-xenial-%: test install Dockerfile.xenial
 	docker run --rm --name spd-xenial-$* -v $(CURDIR):/shinyapps rstudio/shinyapps-package-dependencies:xenial /shinyapps/test $*
 
-test-all-xenial:
+test-all-xenial: test install Dockerfile.xenial
 	docker run --rm --name spd-xenial -v $(CURDIR):/shinyapps rstudio/shinyapps-package-dependencies:xenial /shinyapps/test
 
-test-focal-%:
+test-focal-%: test install Dockerfile.focal
 	docker run --rm --name spd-focal-$* -v $(CURDIR):/shinyapps rstudio/shinyapps-package-dependencies:focal /shinyapps/test $*
 
-test-all-focal:
+test-all-focal: test install Dockerfile.focal
 	docker run --rm --name spd-focal -v $(CURDIR):/shinyapps rstudio/shinyapps-package-dependencies:focal /shinyapps/test
 
 test-all: test-all-focal test-all-xenial

--- a/packages/chromote/install
+++ b/packages/chromote/install
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+set -e
+
+apt-get update -qq
+
+# install chrome
+curl -LO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+apt-get install -y ./google-chrome-stable_current_amd64.deb
+rm google-chrome-stable_current_amd64.deb

--- a/packages/chromote/install_chromium
+++ b/packages/chromote/install_chromium
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -x
+set -e
+
+apt-get update -qq
+
+# On Ubuntu <= 18...
+if [ ${OS_CODENAME} == "xenial" ]; then
+  apt-get install -y chromium-browser
+else
+  ## On Ubuntu Focal...
+  ## When installing chromium using ...
+  # apt-get install -y chromium-browser
+  ## When `chromium` is first ran, an error will be throw, asking you to install chromium using...
+  # snap install chromium
+  ## However, installing `snapd` on docker is not trivial. :-(
+
+
+  # Following directions similar to
+  # * Chromium official suggestion: https://github.com/scheib/chromium-latest-linux/blob/4f4e9b85ea02a109e071452de936389cc2fd7376/update.sh
+  # * GHA Virtual Environments: https://github.com/actions/virtual-environments/blob/cfffe35709dcc45d09f0a08189be5984f3f13bbb/images/linux/scripts/installers/google-chrome.sh#L69-L85
+
+  # Install all dependencies that are not regularly installed when using `.deb` files
+  # https://github.com/puppeteer/puppeteer/blob/feec588f951d8833e3b9758cde9f34c325837407/.ci/node12/Dockerfile.linux#L3-L9
+  # Matches libraries installed when using xenial deb file
+  apt-get install -y xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
+    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
+    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+
+  # Set up variables
+  CHROMIUM_VERSION_FILE="chromiumLastChange.txt"
+  CHROMIUM_ZIP_FILE="chromium.zip"
+  CHROMIUM_ZIP_FOLDER="/tmp/chromium"
+  CHROMIUM_ZIP="${CHROMIUM_ZIP_FOLDER}/${CHROMIUM_ZIP_FILE}"
+
+  mkdir -p "${CHROMIUM_ZIP_FOLDER}"
+
+  # Download chromium latest version. Ex: 382086
+  curl -L4 "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2FLAST_CHANGE?alt=media" -o "${CHROMIUM_VERSION_FILE}"
+  CHROMIUM_VERSION=`cat ${CHROMIUM_VERSION_FILE}`
+  curl -L4 "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F${CHROMIUM_VERSION}%2Fchrome-linux.zip?alt=media" -o "${CHROMIUM_ZIP}"
+
+
+  # Unzip Chromium archive
+  CHROMIUM_FOLDER="/usr/local/share/chromium"
+  CHROMIUM_BIN="$CHROMIUM_FOLDER/chrome-linux/chrome"
+
+  mkdir "${CHROMIUM_FOLDER}"
+  unzip -qq ${CHROMIUM_ZIP} -d "${CHROMIUM_FOLDER}"
+
+  # Link binaries
+  ln -s "${CHROMIUM_BIN}" /usr/bin/chromium
+  ln -s "${CHROMIUM_BIN}" /usr/bin/chromium-browser
+
+fi

--- a/packages/chromote/test.R
+++ b/packages/chromote/test.R
@@ -1,0 +1,26 @@
+options(download.file.method = "curl")
+
+avail_pkgs <- unname(available.packages(repos = "https://cran.rstudio.com")[, "Package"])
+if ("chromote" %in% avail_pkgs) {
+  install.packages("chromote", repos = "https://cran.rstudio.com", type = "source")
+} else {
+  options(repos = c(CRAN="https://cran.rstudio.com"))
+  install.packages(c("curl", "remotes"))
+  remotes::install_github("rstudio/chromote@pkg_updates", dependencies = TRUE)
+}
+
+
+library(chromote)
+
+# Make session
+b <- ChromoteSession$new()
+
+# Download google.com
+b$Page$navigate("https://www.rstudio.com/")
+
+# Get the outer HTML of the document
+outerHTML <- b$DOM$getOuterHTML(b$DOM$getDocument()$root$nodeId)$outerHTML
+print(outerHTML)
+
+# Yell if it doesn't find the close `html` tag; close tag is more consistent
+stopifnot(grepl("</html>", outerHTML, fixed = TRUE))

--- a/packages/chromote/test.R
+++ b/packages/chromote/test.R
@@ -12,6 +12,19 @@ if ("chromote" %in% avail_pkgs) {
 
 library(chromote)
 
+set_default_chromote_object(
+  Chromote$new(
+    Chrome$new(
+      args = c(
+        "--disable-gpu",
+        "--no-sandbox",
+        "--disable-dev-shm-usage", # required bc the target easily crashes
+        c("--force-color-profile", "srgb")
+      )
+    )
+  )
+)
+
 # Make session
 b <- ChromoteSession$new()
 


### PR DESCRIPTION
I'm currently making this a draft PR to post the code for internal questions until a chromote PR is merged into master.


Question: 
- [ ] Any preference on installing chrome vs chromium within the docker images? 
	* Barret: Chrome is TONS easier (and more stable) to perform when installing on Ubuntu Focal. If there is not difference, I'll just install chrome.


----------------

@cderv 

> We recently had a question in a French slack community about webshot2 on shinyapps.io for shinyapps. It was not working as expected.
> 
> So I have worked with Romain Lesur on this to look closer as we already have experience for chrome in pagedown and crrri. He has put together a small example based on the different pieces we discussed for a working solution:
https://community.rstudio.com/t/how-to-properly-configure-google-chrome-on-shinyapps-io-because-of-webshot2/109020/5
> 
> It would be interesting to make that easier probably.
> * chromium should be installed for chromote on shinyapps.io
> * Some args for chrome headless should be passed to chrome as it runs in container on shinyapps.io
> * Making this works seamlessly for users would be easier that knowing the config to make


----------------------

Chromium focal installation related links:
* Why focal is moving from `deb` to `snap`: https://ubuntu.com/blog/chromium-in-ubuntu-deb-to-snap-transition
* Main website: https://www.chromium.org/getting-involved/download-chromium
* Suggest manual installation instructions: https://github.com/scheib/chromium-latest-linux/tree/4f4e9b85ea02a109e071452de936389cc2fd7376
* GHA instructions: https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/google-chrome.sh#L69-L85