### PR TITLE
add snappy support for arrow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ services:
 env:
   - TEST_OS=focal
 
-script:
-  - make test-all-$TEST_OS
+script: 
+  - travis_wait 20 make test-all-$TEST_OS

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ env:
   - TEST_OS=focal
 
 script: 
-  - travis_wait 20 make test-all-$TEST_OS
+  - travis_wait make test-all-$TEST_OS

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ env:
   - TEST_OS=focal
 
 script: 
-  - travis_wait make test-all-$TEST_OS
+  - travis_wait 120 make test-all-$TEST_OS

--- a/packages/arrow/install
+++ b/packages/arrow/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+set -e
+
+apt-get update -qq
+apt-get install -y libsnappy-dev 

--- a/packages/arrow/test.R
+++ b/packages/arrow/test.R
@@ -1,4 +1,5 @@
 # Install from CRAN
+Sys.setenv("LIBARROW_MINIMAL"="false")
 install.packages("arrow", repos = "https://cran.rstudio.com")
 
 # Run example from the manual

--- a/packages/arrow/test.R
+++ b/packages/arrow/test.R
@@ -1,0 +1,10 @@
+# Install from CRAN
+install.packages("arrow", repos = "https://cran.rstudio.com")
+
+# Run example from the manual
+library(arrow)
+if (codec_is_available("snappy")) {
+   print("all is good")
+} else {
+   stop("snappy support still missing")
+}


### PR DESCRIPTION
There is more users adopting and/or trying out the R bindings of the Apache Arrow Framework. While the package as such installs nicely on shinyapps.io, it would be great to get snappy compression enabled. Snappy Compression seems to be the default for parquet files. 

cf. https://community.rstudio.com/t/r-shiny-server-arrow/125384/1 