### PR TITLE
remove the debian imagemagick default policy file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ env:
   - TEST_OS=focal
 
 script: 
-  - travis_wait 120 make test-all-$TEST_OS
+  - travis_wait 180 make test-all-$TEST_OS

--- a/packages/magick/install
+++ b/packages/magick/install
@@ -19,9 +19,7 @@ apt-get install -y libmagick++-dev
 
 
 if [ ${OS_CODENAME} == "focal" ]; then
-  # Enable imagemagick ghostscript features
-  # See https://www.kb.cert.org/vuls/id/332928/
-  # focal has a new enough version of ghostscript
-  sed -i "\$i \ \ <policy domain=\"coder\" rights=\"read | write\" pattern=\"{PS,PS2,PS3,EPS,PDF,XPS}\" />" /etc/ImageMagick-6/policy.xml
+  # the default policy file for debian based imagemagick is overly strict for an environment such as shinapps.io
+  # remove this file to use the default imagemagick policy.
+  rm /etc/ImageMagick-6/policy.xml
 fi
-


### PR DESCRIPTION
@dcaud kindly [opened another PR](https://github.com/rstudio/shinyapps-package-dependencies/pull/321) to adjust the imagemagick policy to enable larger amounts of memory to be used.

After working through the changes required, looking at [imagemagick policy docs](https://imagemagick.org/script/security-policy.php) and having a side conversation with @jeroen about the expectations I think it's best to instead remove the policy altogether.

When magick support was [first added](https://github.com/rstudio/shinyapps-package-dependencies/commit/cc4b25f1a0c87c08dc9fb78409cfa7d12736d44f) to shinyapps.io, the policy installed by the debian package was [far less restrictive](https://salsa.debian.org/debian/imagemagick/-/blob/ca7fe0456001c891bf074890dc3b920154c95ecf/config/policy.xml) (eg. it was not really restrictive at all). Over time, and mainly with our upgrade to focal for these images, the policy has become significantly restrict to account for security and cpu concerns in the generic debian install cases. These cases are not really applicable to the sandboxed-based environments of shinyapps.io and it seems fruitful to put policy needs and desired into the hands of shinyapps.io application deployers, rather than here.

This PR removes the file, and allows imagemagick to make use of its default, non-restrictive, policy for all values.