### PR TITLE
use a smaller file for testing pagedown pdf

### DIFF
--- a/packages/pagedown/test.R
+++ b/packages/pagedown/test.R
@@ -6,7 +6,7 @@ pagedown::find_chrome()
 
 # Test PDF generation (functional test)
 pagedown::chrome_print(
-    file.path(R.home("doc"), "manual", "R-FAQ.html"),
+    file.path(R.home("doc"), "html", "about.html"),
     tempfile(fileext = ".pdf"),
     # use --no-sandbox flag because this code is executed in a container
     extra_args = c("--disable-gpu", "--no-sandbox"),


### PR DESCRIPTION
the existing file is causing total line length limits to be reached in travisci