### PR TITLE
Fix the rselenium tests

### DIFF
--- a/packages/RSelenium/test.R
+++ b/packages/RSelenium/test.R
@@ -1,4 +1,4 @@
 options(download.file.method="curl")
 install.packages("RSelenium", repos="https://cran.rstudio.com")
-rD <- RSelenium::rsDriver(browser = "phantomjs", geckover = NULL)
+rD <- RSelenium::rsDriver(browser = "phantomjs", geckover = NULL, chromever = NULL)
 rD[["server"]]$stop()


### PR DESCRIPTION
It looks like RSelenium is failing to run correctly. The error looks similar to this:

https://github.com/ropensci/RSelenium/issues/264

Since the solution there is to remove a file from chrome, this change will skip the chrome install entirely.