### PR TITLE
Add git2r dependency

### DIFF
--- a/packages/git2r/install
+++ b/packages/git2r/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+set -e
+sudo apt-get update -y
+sudo apt-get install -y libssh2-1

--- a/packages/git2r/test.R
+++ b/packages/git2r/test.R
@@ -1,0 +1,6 @@
+install.packages("git2r")
+library(git2r)
+path <- tempfile(pattern="git2r-")
+dir.create(path)
+repo <- init(path)
+print(config(repo))


### PR DESCRIPTION
hello, 

git2r requires libssh2 to be installed. I hope I have written this right, I am not sure how to test it. 

Once this is merged will I have to do anything extra to deploy my app other than use deployApp() from rsconnect ? I have never used docker before but downloaded it