### PR TITLE
Make rstudio/hosted owner of *

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rstudio/hosted


### PR DESCRIPTION
In combination with branch protection rules on (the newly renamed) `main` branch, will ensure someone has approved any PRs submitted from the public.