### PR TITLE
Add back ImageMagick, just rm debian policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         stack: ${{ fromJSON(needs.list-tests.outputs.matrix) }}
-        os: [focal, jammy]
+        os: [jammy]
     container:
       image: rstudio/shinyapps-package-dependencies:${{ matrix.os }}
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,8 @@ touch packages/[r_package_name]/test.R
 
 5. Write this R script to install the R package and run some basic code to ensure that the package is installed correctly and functional.
 
-4. Test your install by running these commands:
+4. Test your install by running this command:
 
 ```bash
-make test-xenial-[r_package_name]
-make test-focal-[r_package_name]
+make test-jammy-[r_package_name]
 ```

--- a/packages/magick/install
+++ b/packages/magick/install
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+# the default policy file for debian based imagemagick is overly strict for an environment such as shinapps.io
+# remove this file to use the default imagemagick policy.
+rm /etc/ImageMagick-6/policy.xml

--- a/packages/magick/test.R
+++ b/packages/magick/test.R
@@ -1,0 +1,15 @@
+# Install from CRAN
+install.packages("magick", repos = "https://cran.rstudio.com")
+
+# Run example from the manual
+library(magick)
+docdir <- Sys.getenv("R_DOC_DIR", R.home("doc"))
+img <- magick::image_read(file.path(docdir, "html", "logo.jpg"))
+
+# Create a pdf
+image_write(wizard,
+            tempfile(pattern = "pdftemp", fileext = '.pdf'),
+            density = 55,
+            format = 'pdf',
+            comment = "Edit PDFs and Images"
+)


### PR DESCRIPTION
The debian default policy for ImageMagick prevents basic stuff like outputting to a PDF.

We'll remove this from our base environment in time as well, but fixing here will be faster / more lightweight.