### PR TITLE
Add convention to mark a package unsupported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Print Tests
-        run: echo "matrix=$(ls -1 -d packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename | jq -Rsc '. / "\n" - [""]')"
+        run: echo "matrix=$(./test-list.sh | jq -Rsc '. / "\n" - [""]')"
       - name: List Tests As Output
         id: list-tests
-        run: echo "matrix=$(ls -1 -d packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename | jq -Rsc '. / "\n" - [""]')" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(./test-list.sh | jq -Rsc '. / "\n" - [""]')" >> $GITHUB_OUTPUT
 
   test-package:
     name: ${{ matrix.stack }} on ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## October 31st 2023
+
+### Added
+ * Convention to mark packages as no longer officially supported. Packages with an `UNSUPPORTED` file
+   in their directory will not be subject to testing, but may still work for you, espeically if your
+   application uses an old version of the package.
+
+   Packages may be marked unsupported for a variety of reasons, but commonly because they have been
+   removed from CRAN.
+
+### Removed
+ * `rgdal` is marked unsupported because it was removed from CRAN.
+
 ## September 22nd 2023
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
    removed from CRAN.
 
 ### Removed
- * `rgdal` is marked unsupported because it was removed from CRAN.
+ * `rgdal` and `rgeos` is marked unsupported because they were removed from CRAN.
 
 ## September 22nd 2023
 

--- a/packages/rgdal/UNSUPPORTED
+++ b/packages/rgdal/UNSUPPORTED
@@ -1,0 +1,1 @@
+Removed from cran

--- a/packages/rgeos/UNSUPPORTED
+++ b/packages/rgeos/UNSUPPORTED
@@ -1,0 +1,1 @@
+Removed from cran

--- a/test
+++ b/test
@@ -24,7 +24,7 @@ DIR=`dirname $0`
 cd "${DIR}" || exit 1
 
 if [ $# -eq 0 ]; then
-    PACKAGES=$(ls -1 -d $DIR/packages/* | grep -v gsl | tr '\n' '\0' | xargs -0 -n 1 basename)
+    PACKAGES=$(./test-list.sh)
 else
     PACKAGES=$@
 fi

--- a/test-list.sh
+++ b/test-list.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Lists packages that are supported and testable.
+all_packages=$(find packages/ -mindepth 1 -maxdepth 1 -type d)
+
+for package in ${all_packages}; do
+    if [ ! -f "${package}"/UNSUPPORTED ]; then
+        basename "${package}"
+    fi
+done


### PR DESCRIPTION
This allows us to leave package installation scripts present in this repo for users who may want to rebuild old projects with pinned old versions of the package, while providing an escape hatch for CI that would otherwise fail trying to download a current version of an archived package.

Fixes #364