### PR TITLE
RSelenium no longer depends on phantomjs.

### DIFF
--- a/packages/RSelenium/install
+++ b/packages/RSelenium/install
@@ -3,4 +3,4 @@ set -x
 set -e
 
 apt-get update -qq
-DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev phantomjs
+DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev


### PR DESCRIPTION
phantomjs package is also no longer included in ubuntu apt repo -- and the `RSelenium` developer [notes that support for it is suspended.