### PR TITLE
Fix rJava

### DIFF
--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -138,9 +138,6 @@ ARG R_VERSION=4.2.2
 RUN wget -q https://cdn.rstudio.com/r/ubuntu-2004/R-${R_VERSION}-ubuntu-2004.tar.gz -O /tmp/R-${R_VERSION}.tar.gz && \
     mkdir -p /opt/R && \
     tar zx -C /opt/R -f /tmp/R-${R_VERSION}.tar.gz && \
-    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
-    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
-    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm /tmp/R-${R_VERSION}.tar.gz
 
 # set UTF-8

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -91,10 +91,10 @@ RUN wget -q https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.1-lin
     rm julia-1.9.1-linux-x86_64.tar.gz
 
 # Install of texlive. Use --no-install-recommends to avoid installing ~750MB of documentation
-RUN apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    texlive-full && \
-    rm -rf /var/lib/apt/lists/*
+# RUN apt-get update -qq && \
+#     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+#     texlive-full && \
+#     rm -rf /var/lib/apt/lists/*
 
 
 # add in the less secure openssl config file
@@ -117,11 +117,10 @@ COPY Renviron.site /etc/R/Renviron.site
 
 ARG R_VERSION=4.3.1
 
+ENV PATH /opt/R/${R_VERSION}/bin:$PATH
+
 # Install R
 RUN wget -q https://cdn.rstudio.com/r/ubuntu-2204/R-${R_VERSION}-ubuntu-2204.tar.gz -O /tmp/R-${R_VERSION}.tar.gz && \
     mkdir -p /opt/R && \
     tar zx -C /opt/R -f /tmp/R-${R_VERSION}.tar.gz && \
-    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
-    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
-    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm /tmp/R-${R_VERSION}.tar.gz

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -91,10 +91,10 @@ RUN wget -q https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.1-lin
     rm julia-1.9.1-linux-x86_64.tar.gz
 
 # Install of texlive. Use --no-install-recommends to avoid installing ~750MB of documentation
-# RUN apt-get update -qq && \
-#     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-#     texlive-full && \
-#     rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    texlive-full && \
+    rm -rf /var/lib/apt/lists/*
 
 
 # add in the less secure openssl config file

--- a/Renviron.site
+++ b/Renviron.site
@@ -2,5 +2,3 @@ LANG=C.UTF-8
 
 # Otherwise timedatectl will get called which leads to 'no systemd' inside Docker
 TZ=UTC
-
-R_LIBS_USER=/usr/lib/R

--- a/Renviron.site
+++ b/Renviron.site
@@ -2,3 +2,5 @@ LANG=C.UTF-8
 
 # Otherwise timedatectl will get called which leads to 'no systemd' inside Docker
 TZ=UTC
+
+R_LIBS_USER=/usr/lib/R

--- a/packages/rJava/install
+++ b/packages/rJava/install
@@ -5,4 +5,4 @@ set -e
 apt-get update -qq
 apt-get install bzip2 libbz2-dev
 
-/usr/bin/R CMD javareconf
+R CMD javareconf

--- a/test
+++ b/test
@@ -41,9 +41,9 @@ for PACKAGE in $PACKAGES; do
 
         echo " ***** TESTING..." | purple
         if [ -f $PACKAGE_DIR/test.R ]; then
-            sudo R --verbose -f $PACKAGE_DIR/test.R
+            R --verbose -f $PACKAGE_DIR/test.R
         else
-            sudo R -e "install.packages('$PACKAGE', repos='http://cran.rstudio.com/'); library('$PACKAGE')"
+            R -e "install.packages('$PACKAGE', repos='http://cran.rstudio.com/'); library('$PACKAGE')"
         fi
 
         return_code=$?


### PR DESCRIPTION
This adjust the rJava install script to work based of R being on the path rather then at a specific location.

Closes https://github.com/rstudio/shinyapps-package-dependencies/issues/370