### PR TITLE
libarchive required for archive pkg from CRAN -Issue #358

### DIFF
--- a/packages/archive/install
+++ b/packages/archive/install
@@ -4,5 +4,5 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install libarchive-dev
+apt-get install -y libarchive-dev
 


### PR DESCRIPTION
Hello, I am getting a deploy error 

The following additional packages will be installed:
libarchive13
Suggested packages:
lrzip
The following NEW packages will be installed:
libarchive-dev
The following packages will be upgraded:
libarchive13
1 upgraded, 1 newly installed, 0 to remove and 131 not upgraded.
Need to get 950 kB of archives.
After this operation, 2195 kB of additional disk space will be used.
Do you want to continue? [Y/n]

I think this pr would resolve it. 