### PR TITLE
add Cairo

### DIFF
--- a/packages/Cairo/install
+++ b/packages/Cairo/install
@@ -2,7 +2,5 @@
 set -x
 set -e
 
-OS_CODENAME=$(lsb_release -cs)
-
 apt-get update -qq
 apt-get install -y libharfbuzz-icu0 

--- a/packages/Cairo/install
+++ b/packages/Cairo/install
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -x
+set -e
+
+OS_CODENAME=$(lsb_release -cs)
+
+apt-get update -qq
+apt-get install -y libharfbuzz-icu0 

--- a/packages/Cairo/install
+++ b/packages/Cairo/install
@@ -3,4 +3,4 @@ set -x
 set -e
 
 apt-get update -qq
-apt-get install -y libharfbuzz-icu0 
+apt-get install -y pkg-config libharfbuzz-dev libharfbuzz-icu0 

--- a/packages/Cairo/test.R
+++ b/packages/Cairo/test.R
@@ -3,8 +3,7 @@ install.packages("Cairo", repos = "https://cran.rstudio.com")
 
 library("Cairo")
 
-Cairo(5,5)
-
-CairoPNG(filename = "nice.png", width = 600, height = 600)
-
-dev.off()
+if (!Cairo.capabilities()["harfbuzz"]) {
+  cat("Error: Harfbuzz is not available. This script requires harfbuzz.\n")
+  quit(status = 1)
+} 

--- a/packages/Cairo/test.R
+++ b/packages/Cairo/test.R
@@ -3,8 +3,8 @@ install.packages("Cairo", repos = "https://cran.rstudio.com")
 
 library("Cairo")
 
-CairoWin(5,5)
+Cairo(5,5)
 
-CairoPNG(filename = "c:/Users/yourname/nice.png", width = 600, height = 600)
+CairoPNG(filename = "nice.png", width = 600, height = 600)
 
 dev.off()

--- a/packages/Cairo/test.R
+++ b/packages/Cairo/test.R
@@ -1,0 +1,10 @@
+options(download.file.method="curl")
+install.packages("Cairo", repos = "https://cran.rstudio.com")
+
+library("Cairo")
+
+CairoWin(5,5)
+
+CairoPNG(filename = "c:/Users/yourname/nice.png", width = 600, height = 600)
+
+dev.off()


### PR DESCRIPTION
As per https://forum.posit.co/t/error-with-cairo-package-in-shinyapps-io/197671, the `Cairo` package seems to depend on `libharfbuzz-icu0`. 