### PR TITLE
Add system dependencies for geospatial Python packages (GDAL, PROJ, e…

### DIFF
--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -34,7 +34,39 @@ RUN apt-get update -qq && \
     libcairo2 \
     libcairo2-dev \
     libfftw3-dev \
+    libgdal-dev \RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    gdebi-core \
+    jags \
+    libaio1 \
+    libatlas3-base \
+    libcairo2 \
+    libcairo2-dev \
+    libfftw3-dev \
     libgdal-dev \
+    libproj-dev \
+    libspatialindex-dev \
+    libgeos-dev \
+    g++ \
+    python3-dev \
+    libgraphviz-dev \
+    libgsl0-dev \
+    libmysqlclient-dev \
+    libnetcdf-dev \
+    libpcre2-dev \
+    libprocps-dev \
+    libprotoc-dev \
+    libquantlib0-dev \
+    libsasl2-dev \
+    libssh-dev \
+    libsqliteodbc \
+    libxml2-dev \
+    libxt-dev \
+    libxt6 \
+    libspatialindex-dev \
+    libgeos-dev \
+    g++ \
+    python3-dev
     libgraphviz-dev \
     libgsl0-dev \
     libmysqlclient-dev \

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -61,6 +61,10 @@ RUN apt-get update -qq && \
     unixodbc \
     unixodbc-dev \
     wget \
+    libspatialindex-dev \
+    libgeos-dev \
+    g++ \
+    python3-dev \
     zip && \
     rm -f /etc/ImageMagick-6/policy.xml && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request adds essential system libraries required to deploy geospatial Python packages (e.g., `geemap`, `geopandas`, `pyproj`) via `reticulate` in a Shiny app. These include:

- `libgdal-dev`
- `libproj-dev`
- `libspatialindex-dev`
- `libgeos-dev`
- `g++`
- `python3-dev`

These dependencies are critical for a dashboard we’re building at the BC Centre for Disease Control to integrate Google Earth Engine, chlorophyll-a modeling, and public health monitoring across British Columbia. 
Thanks for considering this addition!
