### PR TITLE
Add rule for fs

### DIFF
--- a/packages/fs/install
+++ b/packages/fs/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+set -e
+
+apt-get update -qq
+apt-get install -y libuv1-dev

--- a/packages/fs/test.R
+++ b/packages/fs/test.R
@@ -1,0 +1,2 @@
+options(download.file.method="curl")
+install.packages("fs", repos="https://cran.rstudio.com")


### PR DESCRIPTION
The latest version of the `fs` package now depends on libuv1-dev instead of vendoring it.

Fixes https://github.com/r-lib/fs/issues/514

@mbaynton @stevenolen 🙏 