### PR TITLE
fix the remaining test failures

### DIFF
--- a/packages/RSelenium/test.R
+++ b/packages/RSelenium/test.R
@@ -1,4 +1,7 @@
 options(download.file.method="curl")
 install.packages("RSelenium", repos="https://cran.rstudio.com")
-rD <- RSelenium::rsDriver(browser = "phantomjs", geckover = NULL, chromever = NULL)
-rD[["server"]]$stop()
+rD <- RSelenium::remoteDriver(
+  remoteServerAddr = "localhost",
+  port = 4445L,
+  browserName = "firefox"
+)

--- a/packages/rBLAST/test.R
+++ b/packages/rBLAST/test.R
@@ -1,6 +1,6 @@
-install.packages(c("devtools","BiocManager"), repos="https://cran.rstudio.com")
-BiocManager::install("Biostrings")
-devtools::install_github("mhahsler/rBLAST")
+install.packages(c("BiocManager"), repos="https://cran.rstudio.com")
+BiocManager::install(version = "3.22")
+BiocManager::install("rBLAST")
 library(rBLAST)
 rBLAST::blast_help()
 


### PR DESCRIPTION
rSelenium depended on phantomjs which is long since dead
rBlast depended on devtools which has a few new system deps unrelated to rBlast so stop using it
